### PR TITLE
Bandolier added (and other things)

### DIFF
--- a/RoRStS/src/main/java/riskOfSpire/actions/general/ReduceRandomCostAction.java
+++ b/RoRStS/src/main/java/riskOfSpire/actions/general/ReduceRandomCostAction.java
@@ -1,0 +1,83 @@
+package riskOfSpire.actions.general;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.GetAllInBattleInstances;
+
+import java.util.ArrayList;
+
+public class ReduceRandomCostAction extends AbstractGameAction {
+    private int reduction;
+
+    public ReduceRandomCostAction(int numCards, int reduction)
+    {
+        this.actionType = ActionType.CARD_MANIPULATION;
+        this.reduction = reduction;
+        this.amount = numCards;
+    }
+
+    @Override
+    public void update() {
+        if (amount > 0) {
+            ArrayList<AbstractCard> betterOptions = new ArrayList<>();
+            ArrayList<AbstractCard> worseOptions = new ArrayList<>();
+
+            for (AbstractCard c : AbstractDungeon.player.hand.group)
+            {
+                if (c.costForTurn > 0) {
+                    betterOptions.add(c);
+                } else if (c.cost > 0) {
+                    worseOptions.add(c);
+                }
+            }
+
+            if (betterOptions.size() >= amount)
+            {
+                for (int i = 0; i < amount; i++)
+                {
+                    AbstractCard c = betterOptions.remove(AbstractDungeon.cardRandomRng.random(betterOptions.size() - 1));
+
+                    reduceCost(c);
+                }
+            }
+            else //amount > betterOptions.size
+            {
+                int extraCount = this.amount - betterOptions.size();
+                for (AbstractCard c : betterOptions)
+                {
+                    reduceCost(c);
+                }
+
+                if (worseOptions.size() > extraCount)
+                {
+                    for (int i = 0; i < extraCount; i++)
+                    {
+                        AbstractCard c = worseOptions.remove(AbstractDungeon.cardRandomRng.random(worseOptions.size() - 1));
+
+                        reduceCost(c);
+                    }
+                }
+                else if (worseOptions.size() > 0) //worse options size = or < extraCount
+                {
+                    for (AbstractCard c : worseOptions)
+                    {
+                        reduceCost(c);
+                    }
+                }
+            }
+        }
+
+        this.isDone = true;
+    }
+
+    private void reduceCost(AbstractCard c)
+    {
+        for (AbstractCard copy : GetAllInBattleInstances.get(c.uuid))
+        {
+            copy.modifyCostForCombat(-reduction);
+            if (AbstractDungeon.player.hand.contains(copy))
+                copy.superFlash();
+        }
+    }
+}

--- a/RoRStS/src/main/java/riskOfSpire/relics/Boss/BrilliantBehemoth.java
+++ b/RoRStS/src/main/java/riskOfSpire/relics/Boss/BrilliantBehemoth.java
@@ -1,5 +1,6 @@
 package riskOfSpire.relics.Boss;
 
+import com.badlogic.gdx.math.MathUtils;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.DamageAllEnemiesAction;
 import com.megacrit.cardcrawl.actions.utility.UseCardAction;
@@ -13,7 +14,7 @@ import riskOfSpire.relics.Abstracts.StackableRelic;
 
 public class BrilliantBehemoth extends StackableRelic {
     public static final String ID = RiskOfSpire.makeID("BrilliantBehemoth");
-    public static final double MTPL = 0.3;
+    public static final float MTPL = 0.3F;
 
     public BrilliantBehemoth() {
         super(ID, "BrilliantBehemoth.png", RelicTier.BOSS, LandingSound.HEAVY);
@@ -21,10 +22,11 @@ public class BrilliantBehemoth extends StackableRelic {
 
     @Override
     public void onUseCard(AbstractCard card, UseCardAction action) {
-        if (card.type == AbstractCard.CardType.ATTACK) {
-            double FinalMtpl = Math.pow((1.0 + MTPL), ((double) relicStack));
-            int FinalDmg = (int) Math.floor(card.damage * FinalMtpl);
-            AbstractDungeon.actionManager.addToBottom(new SpawnTolerantDamageAllEnemiesAction(AbstractDungeon.player, FinalDmg, true, false, DamageInfo.DamageType.THORNS, AbstractGameAction.AttackEffect.FIRE, true));
+        if (card.type == AbstractCard.CardType.ATTACK && card.damage > 0) {
+            float finalMult = relicStack * MTPL;
+            int finalDmg = MathUtils.ceil(card.damage * finalMult);
+            this.flash();
+            AbstractDungeon.actionManager.addToBottom(new SpawnTolerantDamageAllEnemiesAction(AbstractDungeon.player, finalDmg, true, false, DamageInfo.DamageType.THORNS, AbstractGameAction.AttackEffect.FIRE, true));
         }
     }
 
@@ -34,7 +36,7 @@ public class BrilliantBehemoth extends StackableRelic {
     }
 
     public String getUpdatedDescription() {
-        double FinalMtpl = Math.pow((1.0 + MTPL), ((double) relicStack));
-        return DESCRIPTIONS[0] + ((100 * FinalMtpl) - 100) + DESCRIPTIONS[1];
+        float finalMult = relicStack * MTPL;
+        return DESCRIPTIONS[0] + MathUtils.floor(100 * finalMult) + DESCRIPTIONS[1];
     }
 }

--- a/RoRStS/src/main/java/riskOfSpire/relics/Uncommon/Bandolier.java
+++ b/RoRStS/src/main/java/riskOfSpire/relics/Uncommon/Bandolier.java
@@ -1,0 +1,40 @@
+package riskOfSpire.relics.Uncommon;
+
+import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import riskOfSpire.RiskOfSpire;
+import riskOfSpire.actions.general.ReduceRandomCostAction;
+import riskOfSpire.relics.Abstracts.StackableRelic;
+
+public class Bandolier extends StackableRelic {
+    public static final String ID = RiskOfSpire.makeID("Bandolier");
+
+    private static final int REDUCTION = 1;
+
+    public Bandolier() {
+        super(ID, "Infusion.png", RelicTier.UNCOMMON, LandingSound.HEAVY);
+    }
+
+    @Override
+    public void onMonsterDeath(AbstractMonster m) {
+        if (m.currentHealth == 0) { //idk gremlin horn does it so I will too
+            if (!AbstractDungeon.getMonsters().areMonstersBasicallyDead()) {
+                AbstractDungeon.actionManager.addToTop(new RelicAboveCreatureAction(m, this));
+                AbstractDungeon.actionManager.addToTop(new ReduceRandomCostAction(this.relicStack, REDUCTION));
+                this.flash();
+            }
+        }
+    }
+
+    @Override
+    public String getUpdatedDescription() {
+        //Upon killing an enemy, reduce the cost of x random card in your hand by 1 this combat.
+        return DESCRIPTIONS[0] + relicStack + (relicStack == 1 ? DESCRIPTIONS[1] : DESCRIPTIONS[2]);
+    }
+
+    public AbstractRelic makeCopy() {
+        return new Bandolier();
+    }
+}

--- a/RoRStS/src/main/java/riskOfSpire/rewards/LinkedRewardItem.java
+++ b/RoRStS/src/main/java/riskOfSpire/rewards/LinkedRewardItem.java
@@ -81,7 +81,8 @@ public class LinkedRewardItem extends RewardItem
     @Override
     public boolean claimReward()
     {
-        this.claimed = super.claimReward() || this.type == RewardType.CARD; //When you click on reward, if it's card or claimed successfully, remove others.
+        boolean claimedReward = super.claimReward();
+        this.claimed = claimedReward || this.type == RewardType.CARD; //When you click on reward, if it's card or claimed successfully, remove others.
         if (this.claimed)
         {
             if (!this.ignoreReward)
@@ -93,11 +94,12 @@ public class LinkedRewardItem extends RewardItem
                     {
                         link.type = RewardType.RELIC;
                         link.relic = new Circlet();
+                        link.move(-1000.0f); //poof, it's gone.
                     }
                 }
             }
         }
-        return claimed;
+        return claimedReward;
     }
 
     @Override

--- a/RoRStS/src/main/java/riskOfSpire/util/StringManipulationUtilities.java
+++ b/RoRStS/src/main/java/riskOfSpire/util/StringManipulationUtilities.java
@@ -8,7 +8,7 @@ import static java.lang.Character.isDigit;
 public class StringManipulationUtilities {
     public static String ordinalNaming(int num) {
         if(Settings.language == Settings.GameLanguage.ENG) {
-            return num + " [REMOVE_SPACE]" + TopPanel.getOrdinalNaming(num);
+            return num + TopPanel.getOrdinalNaming(num);
         }
         return Integer.toString(num);
     }

--- a/RoRStS/src/main/resources/riskOfSpireResources/localization/eng/Relic-Strings.json
+++ b/RoRStS/src/main/resources/riskOfSpireResources/localization/eng/Relic-Strings.json
@@ -13,7 +13,7 @@
     "NAME": "Infusion",
     "FLAVOR": "TODO",
     "DESCRIPTIONS": [
-      "Upon killing an enemy, gain #b1 Max HP, up to #b",
+      "Whenever an enemy dies, gain #b1 Max HP, up to #b",
       "."
     ]
   },
@@ -83,11 +83,20 @@
       " turns of combat, whenever you play a card, gain #b1 #yBlock [REMOVE_SPACE]."
     ]
   },
+  "riskOfSpire:Bandolier": {
+    "NAME": "Bandolier",
+    "FLAVOR": "TODO",
+    "DESCRIPTIONS": [
+      "Whenever an enemy dies, reduce the cost of #b",
+      " random card in your hand by #b1 this combat.",
+      " random cards in your hand by #b1 this combat."
+    ]
+  },
   "riskOfSpire:MonsterTooth": {
     "NAME": "Monster Tooth",
     "FLAVOR": "TODO",
     "DESCRIPTIONS": [
-      "Whenever you kill a non-Minion enemy heal for #b",
+      "Whenever a non-Minion enemy dies, heal #b",
       " HP."
     ]
   },
@@ -199,8 +208,8 @@
     "NAME": "Brilliant Behemoth",
     "FLAVOR": "TODO",
     "DESCRIPTIONS": [
-      "An additional #b",
-      " [REMOVE_SPACE]% of your attack damage is dealt to ALL enemies after playing an attack."
+      "Whenever you play an Attack, deal damage to ALL enemies equal to #b",
+      "% of the Attack's damage."
     ]
   },
   "riskOfSpire:PaulsHoof": {


### PR DESCRIPTION
Brilliant Behemoth Fix
Linked Reward card skip fix
Made the ordinal ending things blue because I think it can be considered part of the number, and it looks weird changing color in the middle of it. (As an example, basegame leaves % after a number blue. I think only stuff like ) or . after #b would matter to avoid making it blue.)